### PR TITLE
1. Accept unknown status when checking tx status. 2. When looking up …

### DIFF
--- a/PostchainClient/Transport/RestClient.cs
+++ b/PostchainClient/Transport/RestClient.cs
@@ -80,7 +80,7 @@ namespace Chromia.Transport
                 throw new ArgumentOutOfRangeException(nameof(blockchainRID), "has to be 32 bytes");
         }
 
-        public async static Task<List<string>> GetNodesFromDirectory(List<Uri> directoryNodeUrls, Buffer blockchainRID, CancellationToken ct)
+        public async static Task<List<Uri>> GetNodesFromDirectory(List<Uri> directoryNodeUrls, Buffer blockchainRID, CancellationToken ct)
         {
             var directoryBrid = await GetDirectoryBridFromNodes(directoryNodeUrls, ct);
             var tmpClient = new RestClient(directoryNodeUrls, directoryBrid);


### PR DESCRIPTION
1. Accept unknown status when checking tx status. 
2. When looking up directory chain, try all nodes in the list before giving up.

Discussion re 1: 
To keep trying whenever we get an "unknown" status is meaningless if we only contact a single node, since this node will always have seen the transaction, and "unknown" would instead signal an error. But if we assume a user would always connect to more than one URL then this behaviour is still the desired one I guess?